### PR TITLE
log path flag

### DIFF
--- a/.semver.yaml
+++ b/.semver.yaml
@@ -1,4 +1,4 @@
 alpha: 2
 beta: 0
 rc: 0
-release: v0.2.2
+release: v0.2.3

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -25,8 +25,6 @@ import (
 	"github.com/pterm/pterm"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
-	"log4jScanner/utils"
 )
 
 // scanCmd represents the scan command
@@ -41,7 +39,6 @@ For example: log4jScanner scan --cidr "192.168.0.1/24`,
 			pterm.DisableColor()
 		}
 
-		utils.PrintHeader()
 		disableServer, err := cmd.Flags().GetBool("noserver")
 		if err != nil {
 			log.Error("server flag error")
@@ -116,8 +113,6 @@ func init() {
 		"Ports to scan. By default scans top 10 ports; 'top100' will scan the top 100 ports, 'slow' will scan all possible ports")
 	scanCmd.Flags().String("csv-output", "",
 		"Set path (inc. filename) to save the CSV file containing the scan results (e.g /tmp/log4jScanner_results.csv). By default will be saved in the running folder.")
-	//scanCmd.Flags().String("log-output","",
-	//	"Set name and path to save the log file (e.g  /tmp/log4jScanner.log). By default will be saved in the running folder")
 	createPrivateIPBlocks()
 }
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -25,8 +25,6 @@ import (
     "github.com/pterm/pterm"
     log "github.com/sirupsen/logrus"
     "github.com/spf13/cobra"
-
-    "log4jScanner/utils"
 )
 
 // serverCmd represents the server command
@@ -35,8 +33,6 @@ var serverCmd = &cobra.Command{
     Short: "run a local TCPServer server",
     Long:  "",
     Run: func(cmd *cobra.Command, args []string) {
-        utils.PrintHeader()
-
         serverUrl, err := cmd.Flags().GetString("server")
         if err != nil {
             fmt.Println("Error in server flag")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,8 +18,6 @@ package cmd
 
 import (
 	"fmt"
-	"log4jScanner/utils"
-
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +27,6 @@ var versionCmd = &cobra.Command{
 	Short: "Get current version",
 	Long:  `Get current version`,
 	Run: func(cmd *cobra.Command, args []string) {
-		utils.PrintHeader()
 		fmt.Println("version:")
 	},
 }

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"log4jScanner/cmd"
 	"log4jScanner/utils"
-	"os"
 )
 
 var (
@@ -31,15 +30,9 @@ var (
 func main() {
 	utils.SetVersion(Version)
 	//utils.PrintHeader()
-	file, err := os.OpenFile("log4jScanner.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
-	// TODO: fix to enable gosec
-	defer file.Close()
-	if err != nil {
-		log.Error("Failed to log to file")
-	}
 
 	utils.InitLogger()
-	utils.GetLogger().SetFile(file)
+	defer utils.Logger.Close()
 	log.WithFields(log.Fields{"buildTime": BuildTime}).Debugf("Version: ", Version)
 
 	//cmd.SetVersionTemplate("test")

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -31,6 +31,14 @@ func GetLogger() *logger{
     return Logger
 }
 
+func (l *logger) Close() error {
+    err := l.File.Close()
+    if err != nil {
+        return err
+    }
+    return nil
+}
+
 func (l *logger) SetLevel(level log.Level){
     l.Level = level
     log.SetLevel(level)


### PR DESCRIPTION
moved header to print when initializing root

`--log-output <path>` with change the location and name of the output log file
if flag is not set using default name (`log4jscanner.log`),
if path is not existing a warning will be printed and will use default name, if creation of default named file failed `log.fatal()`

question why main() have print headers function marked with a comment?
 