### PR TITLE
Expose the http connect timeout value to cli params

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -88,6 +88,13 @@ For example: log4jScanner scan --cidr "192.168.0.1/24`,
 		}
 		initCSV()
 
+		connectTimeout, err := cmd.Flags().GetInt("connect-timeout")
+		if err != nil {
+			pterm.Error.Println("error in connect-timeout flag")
+			cmd.Usage()
+			return
+		}
+
 		serverTimeout, err := cmd.Flags().GetInt("timeout")
 		if err != nil {
 			pterm.Error.Println("error in timeout flag")
@@ -99,7 +106,7 @@ For example: log4jScanner scan --cidr "192.168.0.1/24`,
 		if !disableServer {
 			StartServer(ctx, serverUrl, serverTimeout)
 		}
-		ScanCIDR(ctx, cidr, ports, serverUrl)
+		ScanCIDR(ctx, cidr, ports, serverUrl, connectTimeout)
 	},
 }
 
@@ -118,11 +125,12 @@ func init() {
 		"Ports to scan. By default scans top 10 ports; 'top100' will scan the top 100 ports, 'slow' will scan all possible ports")
 	scanCmd.Flags().String("csv-output", "log4jScanner-results.csv",
 		"Set path (inc. filename) to save the CSV file containing the scan results (e.g /tmp/log4jScanner_results.csv). By default will be saved in the running folder.")
-	scanCmd.Flags().Int("timeout", 10, "Duration of time to wait before closing the callback server, in secods")
+	scanCmd.Flags().Int("timeout", 10, "Duration of time to wait before closing the callback server (in seconds)")
+	scanCmd.Flags().Int("connect-timeout", 2000, "Duration of time to wait for a response from each port while scanning (in milliseconds)")
 	createPrivateIPBlocks()
 }
 
-func ScanCIDR(ctx context.Context, cidr string, portsFlag string, serverUrl string) {
+func ScanCIDR(ctx context.Context, cidr string, portsFlag string, serverUrl string, connectTimeout int) {
 	hosts, err := Hosts(cidr)
 	//if err is not nil cidr wasn't parse correctly or ip isn't private
 	if err != nil {
@@ -183,7 +191,7 @@ func ScanCIDR(ctx context.Context, cidr string, portsFlag string, serverUrl stri
 		wg.Add(1)
 		p.Increment()
 		// TODO: replace with go
-		ScanPorts(i, serverUrl, ports, resChan, &wg)
+		ScanPorts(i, serverUrl, ports, resChan, &wg, connectTimeout)
 	}
 	wg.Wait()
 	if LDAPServer != nil {
@@ -216,7 +224,7 @@ func PrintResults(resChan chan string) {
 	}
 }
 
-func ScanPorts(ip, server string, ports []int, resChan chan string, wg *sync.WaitGroup) {
+func ScanPorts(ip, server string, ports []int, resChan chan string, wg *sync.WaitGroup, connectTimeout int) {
 	defer wg.Done()
 	log.Infof("Trying: %s", ip)
 
@@ -226,8 +234,8 @@ func ScanPorts(ip, server string, ports []int, resChan chan string, wg *sync.Wai
 		targetHttps := fmt.Sprintf("http://%s:%v", ip, port)
 		targetHttp := fmt.Sprintf("https://%s:%v", ip, port)
 		wgPorts.Add(2)
-		go ScanIP(targetHttp, server, &wgPorts, resChan)
-		go ScanIP(targetHttps, server, &wgPorts, resChan)
+		go ScanIP(targetHttp, server, &wgPorts, resChan, connectTimeout)
+		go ScanIP(targetHttps, server, &wgPorts, resChan, connectTimeout)
 	}
 	wgPorts.Wait()
 

--- a/cmd/scanip.go
+++ b/cmd/scanip.go
@@ -14,16 +14,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func ScanIP(hostUrl string, serverUrl string, wg *sync.WaitGroup, resChan chan string) {
+func ScanIP(hostUrl string, serverUrl string, wg *sync.WaitGroup, resChan chan string, connectTimeout int) {
 	defer wg.Done()
-	const timeoutInterval = 2
 
 	client := &http.Client{
-		Timeout: 2 * timeoutInterval * time.Second,
+		Timeout: 2 * time.Duration(connectTimeout) * time.Millisecond,
 		Transport: &http.Transport{
-			TLSHandshakeTimeout:   timeoutInterval * time.Second,
-			ResponseHeaderTimeout: timeoutInterval * time.Second,
-			ExpectContinueTimeout: timeoutInterval * time.Second,
+			TLSHandshakeTimeout:   time.Duration(connectTimeout) * time.Millisecond,
+			ResponseHeaderTimeout: time.Duration(connectTimeout) * time.Millisecond,
+			ExpectContinueTimeout: time.Duration(connectTimeout) * time.Millisecond,
 			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
 		},
 	}


### PR DESCRIPTION
This enables us to quickly scan IP regions if we don't need to wait for
long periods of time, such as scanning reliable LAN networks.

This adds the `--connect-timeout` cli arg which takes a timeout
configuration to use when scanning in milliseconds (default 2000).