### PR TITLE
Expose the http connect timeout value to cli params

### DIFF
--- a/cmd/ldapserver.go
+++ b/cmd/ldapserver.go
@@ -41,7 +41,7 @@ func (s *Server) ReportIP(vulnerableServiceLocation string) {
 		pterm.Error.Println("Failed to parse vulnerable url: " + vulnerableServiceLocation)
 		log.Fatal("Failed to parse server url" + vulnerableServiceLocation)
 	}
-	msg := fmt.Sprintf("SUCCESS: Remote addr: %s", vulnerableServiceLocation)
+	msg := fmt.Sprintf("SUCCESS: Remote addr: %s:%s", vulnUrl.Hostname(), vulnUrl.Port())
 	log.Info(msg)
 	pterm.Success.Println(msg)
 	if s != nil && s.sChan != nil {

--- a/cmd/scanip.go
+++ b/cmd/scanip.go
@@ -16,16 +16,15 @@ import (
 	"log4jScanner/utils"
 )
 
-func ScanIP(hostUrl string, serverUrl string, wg *sync.WaitGroup, resChan chan string) {
+func ScanIP(hostUrl string, serverUrl string, wg *sync.WaitGroup, resChan chan string, connectTimeout int) {
 	defer wg.Done()
-	const timeoutInterval = 2
 
 	client := &http.Client{
-		Timeout: 2 * timeoutInterval * time.Second,
+		Timeout: 2 * time.Duration(connectTimeout) * time.Millisecond,
 		Transport: &http.Transport{
-			TLSHandshakeTimeout:   timeoutInterval * time.Second,
-			ResponseHeaderTimeout: timeoutInterval * time.Second,
-			ExpectContinueTimeout: timeoutInterval * time.Second,
+			TLSHandshakeTimeout:   time.Duration(connectTimeout) * time.Millisecond,
+			ResponseHeaderTimeout: time.Duration(connectTimeout) * time.Millisecond,
+			ExpectContinueTimeout: time.Duration(connectTimeout) * time.Millisecond,
 			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
 		},
 	}


### PR DESCRIPTION
This enables us to quickly scan IP regions if we don't need to wait for
long periods of time, such as scanning reliable LAN networks.

This adds the `--connect-timeout` cli arg which takes a timeout
configuration to use when scanning in milliseconds (default 2000).